### PR TITLE
Revert "Bump actions/download-artifact from 3 to 4.1.7 in /.github/workflows"

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       -
         name: Download artifact
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v3
         with:
           name: dist
           path: ./dist


### PR DESCRIPTION
Reverts theypsilon/display-sim#42